### PR TITLE
Do not change loading status when there is no session.

### DIFF
--- a/components/credential-task/credential-task-directive.js
+++ b/components/credential-task/credential-task-directive.js
@@ -41,8 +41,6 @@ function brCredentialTaskDirective() {
     }).then(function(session) {
       // session does not exist
       if(!session.identity) {
-        // do not display spinner during login process
-        self.loading = false;
         return self.createSession({identity: operation.options.identity});
       }
 
@@ -86,8 +84,8 @@ function brCredentialTaskDirective() {
       self.identity = identity;
       self.credentials = jsonld.getValues(
         self.identity, 'credential').map(function(credential) {
-        return credential['@graph'];
-      });
+          return credential['@graph'];
+        });
       self.choices = self.credentials.slice();
     }).catch(function(err) {
       brAlertService.add('error', err);


### PR DESCRIPTION
When `self.loading` gets set to false here, it causes the template to initialize the `br-identity-composer` with `model.identity` which has not been set yet.

https://github.com/digitalbazaar/bedrock-credential-curator/blob/master/components/credential-task/credential-task.html#L8-L16 

This code path was only utilized when the user does not already have a session established at the IdP.
